### PR TITLE
[BUGFIX] Remove TCA for non existing drop_library_js column

### DIFF
--- a/Configuration/TCA/tx_h5p_domain_model_library.php
+++ b/Configuration/TCA/tx_h5p_domain_model_library.php
@@ -43,15 +43,6 @@ return [
                 'eval' => 'trim',
             ]
         ],
-        'drop_library_js'  => [
-            'exclude' => 0,
-            'label'   => 'LLL:EXT:h5p/Resources/Private/Language/locallang.xlf:tx_h5p_library.drop_library_js',
-            'config'  => [
-                'type' => 'input',
-                'size' => 80,
-                'eval' => 'trim',
-            ]
-        ],
         'embed_types'      => [
             'exclude' => 0,
             'label'   => 'LLL:EXT:h5p/Resources/Private/Language/locallang.xlf:tx_h5p_library.embed_types',

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -13,9 +13,6 @@
             <trans-unit id="tx_h5p_library.drop_library_css">
                 <source>Drop library CSS</source>
             </trans-unit>
-            <trans-unit id="tx_h5p_library.drop_library_js">
-                <source>Drop library JS</source>
-            </trans-unit>
             <trans-unit id="tx_h5p_library.embed_types">
                 <source>Embed types</source>
             </trans-unit>


### PR DESCRIPTION
The column is not defined in `ext_tables.sql` and can cause problems when copying records.