### PR TITLE
[BUGFIX] Fix TCA for is_recommended column in content type cache

### DIFF
--- a/Configuration/TCA/tx_h5p_domain_model_contenttypecacheentry.php
+++ b/Configuration/TCA/tx_h5p_domain_model_contenttypecacheentry.php
@@ -115,7 +115,7 @@ return [
                 'eval' => 'trim',
             ]
         ],
-        'isrecommended'     => [
+        'is_recommended'     => [
             'exclude' => 0,
             'label'   => 'LLL:EXT:h5p/Resources/Private/Language/locallang.xlf:tx_h5p_domain_model_contenttypecacheentry.isRecommended',
             'config'  => [


### PR DESCRIPTION
The column is named `is_recommended` in the `ext_tables.sql` file and the property is called `$isRecommended` in the domain model. So the TCA entry should also have an underscore.