### PR TITLE
[BUGFIX] Prevent invalid null value for content license version

### DIFF
--- a/Classes/Domain/Model/Content.php
+++ b/Classes/Domain/Model/Content.php
@@ -204,7 +204,7 @@ class Content extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
             $this->setAuthors(empty($contentData['metadata']->authors) ? null : json_encode($contentData['metadata']->authors));
             $this->setSource(empty($contentData['metadata']->source) ? null : $contentData['metadata']->source);
             $this->setLicense(empty($contentData['metadata']->license) ? '' : $contentData['metadata']->license);
-            $this->setLicenseVersion(empty($contentData['metadata']->licenseVersion) ? null : $contentData['metadata']->licenseVersion);
+            $this->setLicenseVersion(empty($contentData['metadata']->licenseVersion) ? '' : $contentData['metadata']->licenseVersion);
             $this->setLicenseExtras(empty($contentData['metadata']->licenseExtras) ? null : $contentData['metadata']->licenseExtras);
             $this->setAuthorComments(empty($contentData['metadata']->authorComments) ? null : $contentData['metadata']->authorComments);
             $this->setChanges(empty($contentData['metadata']->changes) ? null : json_encode($contentData['metadata']->changes));


### PR DESCRIPTION
The field is not nullable in the database, therefore we use
an empty string as fallback if the version is not available.