### PR TITLE
[BUGFIX] Prevent call to non existing init method in file utility

### DIFF
--- a/Classes/Adapter/Core/FileStorage.php
+++ b/Classes/Adapter/Core/FileStorage.php
@@ -454,7 +454,9 @@ class FileStorage implements \H5PFileStorage, SingletonInterface
         $this->registerUploadField($data, $namespace, $targetFalDirectory, $editorFilename);
 
         $fileProcessor = GeneralUtility::makeInstance(ExtendedFileUtility::class);
-        $fileProcessor->init([], []);
+        if (method_exists($fileProcessor, 'init')) {
+            $fileProcessor->init([], []);
+        }
         $fileProcessor->setActionPermissions();
         $fileProcessor->start($data);
         $fileProcessor->setExistingFilesConflictMode(DuplicationBehavior::REPLACE);


### PR DESCRIPTION
The init method was removed in version 8.3.

See:
https://forge.typo3.org/issues/77182