### PR TITLE
[BUGFIX] Remove leading backslash from Extbase object config

### DIFF
--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -19,7 +19,7 @@ config.tx_extbase {
     }
 
     objects {
-        TYPO3\CMS\Extbase\Domain\Model\FileReference.className = \MichielRoos\H5p\Domain\Model\FileReference
+        TYPO3\CMS\Extbase\Domain\Model\FileReference.className = MichielRoos\H5p\Domain\Model\FileReference
     }
 }
 


### PR DESCRIPTION
Prevent TYPO3 9 from throwing an Exception when creating an
instance of the core FileReference model.