### PR TITLE
Fix autoloader problem in non composer typo3 inst

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,6 +19,7 @@ $EM_CONF['h5p'] = [
         'suggests'     => [],
     ],
     'autoload'         => [
+        'classmap'=> ["Resources/Public/Lib"],
         'psr-4' => ['MichielRoos\\H5p\\' => 'Classes']
     ],
     'conflicts'        => '',


### PR DESCRIPTION
This fix autoloading in non composer installations by adding the folder Resources/Public/Lib to the autloading. Works for me in typo3 10