### PR TITLE
set h5p/* composer version to 1.24.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         }
     ],
     "require": {
-        "h5p/h5p-core": "^1.24",
-        "h5p/h5p-editor": "^1.24",
+        "h5p/h5p-core": "1.24.*",
+        "h5p/h5p-editor": "1.24.*",
         "guzzlehttp/guzzle": "^7.4",
         "typo3/cms-core": "11.5.*"
     },


### PR DESCRIPTION
Temporary fix until https://packagist.org/packages/h5p/h5p-core v1.25 get published.

ref: https://github.com/Tuurlijk/t3ext-h5p/issues/37 